### PR TITLE
bugfix: fixing a bug where a texutre isn't cleared when expected

### DIFF
--- a/src/SourceNodes/sourcenode.js
+++ b/src/SourceNodes/sourcenode.js
@@ -310,22 +310,16 @@ class SourceNode extends GraphNode {
 
         if (this._state === STATE.waiting) return;
         if (time < this._startTime) {
-            // A quick check to ensure we don't call 'clearTexture' every RAF when only needed once
-            if (this._state != STATE.sequenced) {
-                clearTexture(this._gl, this._texture);
-                this._state = STATE.sequenced;
-            }
+            clearTexture(this._gl, this._texture);
+            this._state = STATE.sequenced;
         }
         if (time >= this._startTime && this._state !== STATE.paused) {
             this._state = STATE.playing;
         }
         if (time >= this._stopTime) {
-            // A quick check to ensure we don't call 'clearTexture' every RAF when only needed once
-            if (this._state != STATE.ended) {
-                clearTexture(this._gl, this._texture);
-                this._triggerCallbacks("ended");
-                this._state = STATE.ended;
-            }
+            clearTexture(this._gl, this._texture);
+            this._triggerCallbacks("ended");
+            this._state = STATE.ended;
         }
         //update the current time
         this._currentTime = time;
@@ -377,11 +371,8 @@ class SourceNode extends GraphNode {
         this._triggerCallbacks("render", currentTime);
 
         if (currentTime < this._startTime) {
-            // A quick check to ensure we don't call 'clearTexture' every RAF when only needed once
-            if (this._state != STATE.sequenced) {
-                clearTexture(this._gl, this._texture);
-                this._state = STATE.sequenced;
-            }
+            clearTexture(this._gl, this._texture);
+            this._state = STATE.sequenced;
         }
 
         if (
@@ -394,12 +385,9 @@ class SourceNode extends GraphNode {
         }
 
         if (currentTime >= this._stopTime) {
-            // A quick check to ensure we don't call 'clearTexture' every RAF when only needed once
-            if (this._state != STATE.ended) {
-                clearTexture(this._gl, this._texture);
-                this._triggerCallbacks("ended");
-                this._state = STATE.ended;
-            }
+            clearTexture(this._gl, this._texture);
+            this._triggerCallbacks("ended");
+            this._state = STATE.ended;
         }
 
         //update this source nodes texture

--- a/src/utils.js
+++ b/src/utils.js
@@ -77,22 +77,29 @@ export function updateTexture(gl, texture, element) {
     gl.bindTexture(gl.TEXTURE_2D, texture);
     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, element);
+
+    texture._isTextureCleared = false;
 }
 
 export function clearTexture(gl, texture) {
-    gl.bindTexture(gl.TEXTURE_2D, texture);
-    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
-    gl.texImage2D(
-        gl.TEXTURE_2D,
-        0,
-        gl.RGBA,
-        1,
-        1,
-        0,
-        gl.RGBA,
-        gl.UNSIGNED_BYTE,
-        new Uint8Array([0, 0, 0, 0])
-    );
+    // A quick check to ensure we don't call 'texImage2D' when the texture has already been 'cleared' #performance
+    if (!texture._isTextureCleared) {
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+        gl.texImage2D(
+            gl.TEXTURE_2D,
+            0,
+            gl.RGBA,
+            1,
+            1,
+            0,
+            gl.RGBA,
+            gl.UNSIGNED_BYTE,
+            new Uint8Array([0, 0, 0, 0])
+        );
+
+        texture._isTextureCleared = true;
+    }
 }
 
 export function generateRandomId() {


### PR DESCRIPTION
this is due to start() and startAt() setting STATE to be STATE.sequenced before a clearTexture is called.